### PR TITLE
fix paging if sendmail command writes to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 This single-file Python script `mutt-ical.py` displays and replies to [Icalendar](https://tools.ietf.org/html/rfc5545) invitations (.ics files) from mutt.
-It requires Mutt, Bash and Python with the [Vobject](https://github.com/py-vobject/vobject) Python package which can be installed with `pip install --user vobject`.
+It requires Mutt and Python with the [Vobject](https://github.com/py-vobject/vobject) Python package that can be installed with `pip install --user git+https://github.com/py-vobject/vobject`.
 
 Installing
 ----------

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ alternative_order text/calendar text/x-vcalendar application/ics text/plain text
 
 Here the second line ensures that the calendar entry is displayed before the message text.
 
-- To reply to a calendar entry by pressing `r` in the attachment view (usually opened by hitting `v` after having selected a mail in mutt), add to your .muttrc a line such as
+- To answer a calendar entry by pressing `a` in the attachment view (usually opened by hitting `v` after having selected a mail in mutt), add to your .muttrc a line such as
 
 ```muttrc
-macro attach r \
+macro attach a \
     "<pipe-entry>iconv -c --to-code=UTF-8 > ~/.cache/mutt.ics<enter><shell-escape>~/bin/mutt-ical.py -i -e your.email@address -s 'msmtp --account=work' ~/.cache/mutt.ics<enter>" \
-    "reply to appointment request"
+    "answer appointment request"
 ```
 
 Here you need to customize the email address `your.email@address` and the send command `msmtp --account=work`.
@@ -42,7 +42,7 @@ If `-s` is not set, the Mutt setting `$sendmail` will be used.
 - To optionally open the Icalendar in your favorite desktop calendar application, such as `Ical`, run `xdg-open ~/.cache/mutt.ics` (on Linux, respectively `open ~/.cache/mutt.ics` on Mac OS) after the `mutt-ical.py` command, for example
 
 ```muttrc
-macro attach r \
+macro attach a \
     "<pipe-entry>iconv -c --to-code=UTF-8 > ~/.cache/mutt.ics<enter><shell-escape>~/bin/mutt-ical.py -i -e your.email@address -s 'msmtp --account=work' ~/.cache/mutt.ics && xdg-open ~/.cache/mutt.ics<enter>" \
     "reply to appointment request"
 ```
@@ -54,12 +54,12 @@ Usage
 If you configure auto_view (as above), then the description should be visible in
 the pager.
 (Otherwise view the attachements (usually by hitting 'v'), select and open the `Icalendar` entry.)
-To reply, just open the `Icalendar` file from mutt:
+To answer, just open the `Icalendar` file from mutt:
 
 * View the attachements (usually 'v')
 * Select the text/calendar entry
-* Hit 'r'
-* Choose your reply
+* Hit 'a'
+* Choose your answer
 
 
 Documentation
@@ -69,11 +69,11 @@ The script supports the following options: `-i`, `-a`, `-d`, `-t`, `-D`, and `-s
 If the `-D` option is used, the script will display the event details and terminate without sending any replies.
 The `-i`, `-a`, `-d`, and `-t` options are mutually exclusive;
 the last one specified determines the response type sent.
-By default, the script will use Mutt's sendmail setting to send the reply, unless the `-s` option is used to override it.
+By default, the script will use Mutt's sendmail setting to send the answer, unless the `-s` option is used to override it.
 
 ```sh
 -e <your.email@address>
-    Specify the email address to send the reply from. This should be the email address that received the invitation.
+    Specify the email address to send the answer from. This should be the email address that received the invitation.
 
 -i
     Interactive mode. Prompt for user input to accept, decline, or tentatively accept the invitation.
@@ -88,7 +88,7 @@ By default, the script will use Mutt's sendmail setting to send the reply, unles
     Tentatively accept the invitation automatically without prompting.
 
 -D
-    Display only. Show the event details but do not send any reply.
+    Display only. Show the event details but do not send any answer.
 
 -s <sendmail command>
     Specify the sendmail command to use for sending the email. If not set, the default Mutt setting will be used.

--- a/README.md
+++ b/README.md
@@ -1,80 +1,123 @@
-mutt-ical.py is meant as a simple way to display and reply to ical invitations from mutt.
-
-Warning
--------
-
-This script was written during a few days in 2013 for Python 2. I currently do
-not use it myself. There might be still issues with recent versions of Python 3.
-
-If this script does not work for you, please consider fixing it yourself. It
-is just a few lines of code after all.
-
-Pull requests are accepted, but please do not expect me to test them, they
-will be merged after a quick and shallow review.
-
-You have been warned.
+This single-file Python script `mutt-ical.py` displays and replies to [Icalendar](https://tools.ietf.org/html/rfc5545) invitations (.ics files) from mutt.
+It requires Mutt, Bash and Python with the [Vobject](https://github.com/py-vobject/vobject) Python package which can be installed with `pip install --user vobject`.
 
 Installing
 ----------
 
-* Copy it into somewhere in your PATH, (or you can specify the PATH in your .mailcap)
-* Edit your mailcap (~/.mailcap or /etc/mailcap) to have the following line:
+Copy the script into a folder in your `$PATH`, (or specify the `$PATH` in your `mailcap` and `muttrc` files).
+Mark it executable by `chmod +x`.
+We will assume that you copied it into `~/bin` so that its full path is `~/bin/mutt-ical.py`.
 
-```
-# for replying
-text/calendar; <path>mutt-ical.py -i -e "user@domain.tld" %s
-application/ics; <path>mutt-ical.py -i -e "user@domain.tld" %s
-# for auto-view
-text/calendar; <path>mutt-ical.py -D %s; copiousoutput
-application/ics; <path>mutt-ical.py -D %s; copiousoutput
-```
-(Don't forget to add your email address)
+Initial Setup
+-------------
 
-* if you want to use auto view in the pager, use something like the following in .muttrc
-   (just an example, configure text/plain and text/html at your own discretion)
+* To view the calendar entry in mutt by opening the calendar entry in the attachment view (usually opened by hitting `v` after having selected a mail in mutt), add to your `mailcap` file (found at '`~/.mailcap`, `/etc/mailcap` or `$mailcap_path` set in `muttrc`) the following lines:
 
-```
-auto_view text/calendar text/plain text/html
-alternative_order text/calendar text/plain text/html
+```muttrc
+text/calendar;    ~/bin/mutt-ical.py -D %s; copiousoutput
+text/x-vcalendar; ~/bin/mutt-ical.py -D %s; copiousoutput
+application/ics;  ~/bin/mutt-ical.py -D %s; copiousoutput
 ```
 
+- To view the calendar entry by opening a selected a mail in mutt, add to your .muttrc the following lines:
 
-OSX Users
----------
-
-* For added fun on OSX, you can extend it to the following, to get iCal to open it nicely too (iCal does not care for mime types it seems):
+```muttrc
+auto_view text/calendar text/x-vcalendar application/ics text/plain text/html
+alternative_order text/calendar text/x-vcalendar application/ics text/plain text/html
 ```
-text/calendar; mv %s %s.ics && open %s.ics && <path>mutt-ical.py -i -e "user@domain.tld" %s.ics && rm %s.ics
-```
-* You can force iCal to stop trying to send mail on your behalf by replacing
-the file `/Applications/iCal.app/Contents/Resources/Scripts/Mail.scpt` with your
-own ActionScript. I went with the following: `error number -128`
-Which tells it that the user cancelled the action.
 
-    * Open AppleScript Editor, paste the code from above into a new script, then save it.
-    * Move the old script `/Applications/iCal.app/Contents/Resources/Scripts/Mail.scpt`  just in case you want to re-enable the functionality.
-    * Copy your new script into place.
+Here the second line ensures that the calendar entry is displayed before the message text.
+
+- To reply to a calendar entry by pressing `r` in the attachment view (usually opened by hitting `v` after having selected a mail in mutt), add to your .muttrc a line such as
+
+```muttrc
+macro attach r \
+    "<pipe-entry>iconv -c --to-code=UTF-8 > ~/.cache/mutt.ics<enter><shell-escape>~/bin/mutt-ical.py -i -e your.email@address -s 'msmtp --account=work' ~/.cache/mutt.ics<enter>" \
+    "reply to appointment request"
+```
+
+Here you need to customize the email address `your.email@address` and the send command `msmtp --account=work`.
+If `-s` is not set, the Mutt setting `$sendmail` will be used.
+
+- To optionally open the Icalendar in your favorite desktop calendar application, such as `Ical`, run `xdg-open ~/.cache/mutt.ics` (on Linux, respectively `open ~/.cache/mutt.ics` on Mac OS) after the `mutt-ical.py` command, for example
+
+```muttrc
+macro attach r \
+    "<pipe-entry>iconv -c --to-code=UTF-8 > ~/.cache/mutt.ics<enter><shell-escape>~/bin/mutt-ical.py -i -e your.email@address -s 'msmtp --account=work' ~/.cache/mutt.ics && xdg-open ~/.cache/mutt.ics<enter>" \
+    "reply to appointment request"
+```
+
 
 Usage
 -----
 
-If you configure auto_view (see above), the description should be visible in
+If you configure auto_view (as above), then the description should be visible in
 the pager.
+(Otherwise view the attachements (usually by hitting 'v'), select and open the `Icalendar` entry.)
+To reply, just open the `Icalendar` file from mutt:
 
-To reply, just open the ical file from mutt:
 * View the attachements (usually 'v')
 * Select the text/calendar entry
-* Invoke the mailcap entry (usually 'm')
+* Hit 'r'
 * Choose your reply
 
-An old sendmail wrapper is also included, but since mutt's SMTP support has now improved, rather configure your SMTP settings through mutt's config. The wrapper is kept in case someone finds it useful. However, the get_mutt_command function will need the relevant code uncommented to use it.
 
-Requirements
+Documentation
+-------------
+
+The script supports the following options: `-i`, `-a`, `-d`, `-t`, `-D`, and `-s`. The `-e` option followed by an email address and the path to an `.ics` file are required.
+If the `-D` option is used, the script will display the event details and terminate without sending any replies.
+The `-i`, `-a`, `-d`, and `-t` options are mutually exclusive;
+the last one specified determines the response type sent.
+By default, the script will use Mutt's sendmail setting to send the reply, unless the `-s` option is used to override it.
+
+```sh
+-e <your.email@address>
+    Specify the email address to send the reply from. This should be the email address that received the invitation.
+
+-i
+    Interactive mode. Prompt for user input to accept, decline, or tentatively accept the invitation.
+
+-a
+    Accept the invitation automatically without prompting.
+
+-d
+    Decline the invitation automatically without prompting.
+
+-t
+    Tentatively accept the invitation automatically without prompting.
+
+-D
+    Display only. Show the event details but do not send any reply.
+
+-s <sendmail command>
+    Specify the sendmail command to use for sending the email. If not set, the default Mutt setting will be used.
+
+filename.ics
+    The .ics file to be processed. This should be the invitation file received.
+
+Usage:
+
+    mutt-ical.py [OPTIONS] -e your@email.address filename.ics
+```
+
+Make sure to replace the placeholder `your.email@address` with your actual email address and  `filename.ics` with the path to the .ics file when running the script.
+
+Hints
+-----
+
+Mac OS X iCal Users can force iCal to stop trying to send mail on your behalf by replacing
+the file `/Applications/iCal.app/Contents/Resources/Scripts/Mail.scpt` with your
+own ActionScript. Martin Sander went with the following: `error number -128`
+Which tells it that the user cancelled the action.
+
+* Open AppleScript Editor, paste the code from above into a new script, then save it.
+* Move the old script `/Applications/iCal.app/Contents/Resources/Scripts/Mail.scpt`  just in case you want to re-enable the functionality.
+* Copy your new script into place.
+
+Inspiration
 ------------
 
-mutt, python, bash, vobject:
-http://vobject.skyhouseconsulting.com/ or 'easy_install vobject'
+This forks [Martin Sander's](https://github.com/marvinthepa/mutt-ical/) whose (MIT) license restrictions apply, and which was inspired by
+[accept.py](http://weirdzone.ru/~veider/accept.py) and [Rubyforge.org Samples](http://vpim.rubyforge.org/files/samples/README_mutt.html).
 
-Inspired by:
-* http://weirdzone.ru/~veider/accept.py
-* http://vpim.rubyforge.org/files/samples/README_mutt.html

--- a/mutt-ical.py
+++ b/mutt-ical.py
@@ -215,14 +215,22 @@ if __name__ == "__main__":
 
     summary = ans.vevent.contents['summary'][0].value
     accept_decline = accept_decline.capitalize()
-    subject = f"'{accept_decline}: {summary}'"
+    subject = f"{accept_decline}: {summary}"
     to = organizer(ans)
 
     message = EmailMessage()
     message['From'] = email_address
     message['To'] = to
     message['Subject'] = subject
-    mailtext = f"{email_address} has {accept_decline.lower()}"
+    if accept_decline.lower() == "accepted":
+        mailtext = f"Thank you for the invitation. I, {email_address}, will be attending."
+    elif accept_decline.lower() == "tentative":
+        mailtext = f"Thank you for the invitation. I, {email_address}, am tentatively available and have marked this time on my calendar."
+    elif accept_decline.lower() == "declined":
+        mailtext = f"Thank you for the invitation. Unfortunately, I, {email_address}, will not be able to attend."
+    else:
+        mailtext = "Invalid response type provided."
+
     message.add_alternative(mailtext, subtype='plain')
     message.add_alternative(ans.serialize(),
             subtype='calendar',

--- a/mutt-ical.py
+++ b/mutt-ical.py
@@ -203,10 +203,10 @@ if __name__ == "__main__":
     flag = 1
     for attendee in attendees:
         if hasattr(attendee, 'EMAIL_param'):
-            if attendee.EMAIL_param == email_address:
+            if attendee.EMAIL_param.lower() == email_address.lower():
                 ans.vevent.attendee_list.append(attendee)
                 flag = 0
-        elif attendee.value.split(':')[1] == email_address:
+        elif attendee.value.split(':')[1].lower() == email_address.lower():
             ans.vevent.attendee_list.append(attendee)
             flag = 0
     if flag:

--- a/mutt-ical.py
+++ b/mutt-ical.py
@@ -218,18 +218,32 @@ if __name__ == "__main__":
     subject = f"{accept_decline}: {summary}"
     to = organizer(ans)
 
+    ans.vevent.add('priority')
+    ans.vevent.priority.value = '5'
+
     message = EmailMessage()
     message['From'] = email_address
     message['To'] = to
     message['Subject'] = subject
     if accept_decline.lower() == "accepted":
         mailtext = f"Thank you for the invitation. I, {email_address}, will be attending."
+
+        ans.vevent.add('status')
+        ans.vevent.status.value = 'CONFIRMED'
+        ans.vevent.add('x-microsoft-cdo-busystatus')
+        ans.vevent.x_microsoft_cdo_busystatus.value = 'BUSY'
     elif accept_decline.lower() == "tentative":
         mailtext = f"Thank you for the invitation. I, {email_address}, am tentatively available and have marked this time on my calendar."
+
+        ans.vevent.add('status')
+        ans.vevent.status.value = 'TENTATIVE'
+        ans.vevent.add('x-microsoft-cdo-busystatus')
+        ans.vevent.x_microsoft_cdo_busystatus.value = 'TENTATIVE'
     elif accept_decline.lower() == "declined":
         mailtext = f"Thank you for the invitation. Unfortunately, I, {email_address}, will not be able to attend."
     else:
         mailtext = "Invalid response type provided."
+
 
     message.add_alternative(mailtext, subtype='plain')
     message.add_alternative(ans.serialize(),

--- a/mutt-ical.py
+++ b/mutt-ical.py
@@ -3,6 +3,12 @@
 """
 This script is meant as a simple way to reply to ical invitations from mutt.
 See README for instructions and LICENSE for licensing information.
+
+Note on dependencies and compatibility:
+- This script depends on the 'vobject' package for iCalendar parsing/serialization.
+- Ensure a recent 'vobject' (e.g., 0.9.7 or newer) is installed for best compatibility with modern Python.
+- Some older 'vobject' versions may have issues with recent Python releases. If you encounter parsing/serialization problems,
+  consider upgrading 'vobject' or using an alternative like 'icalendar'.
 """
 
 __author__ = "Martin Sander"
@@ -12,7 +18,9 @@ import locale
 import subprocess
 import sys
 import time
-from datetime import datetime
+import shlex
+import re
+from datetime import datetime, timezone
 from email.message import EmailMessage
 from getopt import gnu_getopt as getopt
 
@@ -37,17 +45,20 @@ def del_if_present(dic, key):
 
 
 def set_accept_state(attendees, state):
+    # Normalize RSVP-related parameters for each attendee and set participation status
+    if not isinstance(attendees, list):
+        return attendees
     for attendee in attendees:
+        if not hasattr(attendee, "params"):
+            continue
         attendee.params['PARTSTAT'] = [state]
         for i in ["RSVP", "ROLE", "X-NUM-GUESTS", "CUTYPE"]:
-            # del_if_present(attendee.params, i)
-            def del_if_present(dic: dict, key: str) -> None:
-                if key in dic:
-                    del dic[key]
+            del_if_present(attendee.params, i)
     return attendees
 
 
 def get_accept_decline():
+    # Get user input for accept/decline/tentative/cancel in interactive mode
     while True:
         sys.stdout.write("\nAccept Invitation? [Y]es/[n]o/[t]entative/[c]ancel\n")
         ans = sys.stdin.readline()
@@ -63,7 +74,7 @@ def get_accept_decline():
 
 
 def get_answer(invitation):
-    # create
+    # Build the REPLY VCALENDAR/VEVENT from the invitation
     ans = vobject.newFromBehavior('vcalendar')
     ans.add('method')
     ans.method.value = "REPLY"
@@ -76,15 +87,16 @@ def get_answer(invitation):
 
     # new timestamp
     ans.vevent.add('dtstamp')
-    # ans.vevent.dtstamp.value = datetime.utcnow().replace(
-    #         tzinfo=invitation.vevent.dtstamp.value.tzinfo)
-    ans.vevent.dtstamp.value = datetime.now(tz=invitation.vevent.dtstamp.value.tzinfo)
+    ans.vevent.dtstamp.value = datetime.now(timezone.utc)
     return ans
 
 
 def execute(command, mailtext):
+    # Execute an external command optionally feeding it data through stdin
     process = subprocess.Popen(command, stdin=subprocess.PIPE)
-    if process.stdin is not None:
+    if process.stdin is not None and mailtext is not None:
+        if isinstance(mailtext, str):
+            mailtext = mailtext.encode()
         process.stdin.write(mailtext)
         process.stdin.close()
 
@@ -99,17 +111,23 @@ def execute(command, mailtext):
 
 
 def openics(invitation_file):
+    # Open and parse the ICS invitation file
     with open(invitation_file, encoding=locale.getpreferredencoding(False)) as f:
         return vobject.readOne(f, ignoreUnreadable=True)
 
 
 def format_date(value: datetime) -> str:
+    # Format a datetime-like value for display in local timezone when possible
     if isinstance(value, datetime):
-        return value.astimezone(tz=None).strftime("%Y-%m-%d %H:%M %z")
+        try:
+            return value.astimezone(tz=None).strftime("%Y-%m-%d %H:%M %z")
+        except Exception:
+            return value.strftime("%Y-%m-%d %H:%M %z")
     return value.strftime("%Y-%m-%d %H:%M %z")
 
 
 def display(ical):
+    # Display event details to the user
     summary = ical.vevent.contents['summary'][0].value
     if 'organizer' in ical.vevent.contents:
         if hasattr(ical.vevent.organizer, 'EMAIL_param'):
@@ -122,7 +140,7 @@ def display(ical):
         description = ical.vevent.contents['description'][0].value
     else:
         description = "NO DESCRIPTION"
-    attendees = ical.vevent.contents.get("attendee", "")
+    attendees = ical.vevent.contents.get("attendee", [])
     locations = ical.vevent.contents.get("location", None)
     sys.stdout.write("From:\t" + sender + "\n")
     sys.stdout.write("Title:\t" + summary + "\n")
@@ -133,9 +151,9 @@ def display(ical):
         else:
             try:
                 sys.stdout.write(attendee.CN_param + " <" + attendee.value.split(':')[1] + ">, ")  # workaround for MS
-            except Exception as e:
+            except Exception:
                 # workaround for 'mailto:' in email
-                sys.stdout.write(attendee.value.split(':')[1] + " <" + attendee.value.split(':')[1] + ">, ") 
+                sys.stdout.write(attendee.value.split(':')[1] + " <" + attendee.value.split(':')[1] + ">, ")
     sys.stdout.write("\n")
     if hasattr(ical.vevent, 'dtstart'):
         print(f"Start:\t{format_date(ical.vevent.dtstart.value)}")
@@ -151,31 +169,32 @@ def display(ical):
     sys.stdout.write(description + "\n")
 
 
-    import subprocess
-
 def sendmail_command():
-    try:
-        # Try with 'mutt' first
-        output = subprocess.check_output(["mutt", "-Q", "sendmail"], stderr=subprocess.STDOUT)
-        output = output.strip().decode()
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    # Detect the configured sendmail command from mutt/neomutt configuration
+    for mutt in ("mutt", "neomutt"):
         try:
-            # Fallback to 'neomutt' if 'mutt' fails
-            output = subprocess.check_output(["neomutt", "-Q", "sendmail"], stderr=subprocess.STDOUT)
-            output = output.strip().decode()
+            output = subprocess.check_output([mutt, "-Q", "sendmail"], stderr=subprocess.STDOUT)
+            out = output.strip().decode()
         except (subprocess.CalledProcessError, FileNotFoundError):
-            # Neither 'mutt' nor 'neomutt' is available
-            return None
+            continue
 
-    # Use regex to find the sendmail setting
-    match = re.search(r'set\s+sendmail\s*=\s*"([^"]+)"', output)
-    if match:
-        sendmail_command = match.group(1).split()
-        return sendmail_command
-    else:
-        return None
+        match = re.search(r'sendmail\s*=\s*"([^"]+)"', out)
+        if match:
+            return shlex.split(match.group(1))
+
+        match = re.search(r'sendmail\s*=\s*(\S.*)$', out)
+        if match:
+            return shlex.split(match.group(1))
+
+        if out:
+            out = out.strip('"')
+            return shlex.split(out)
+
+    return None
+
 
 def organizer(ical):
+    # Extract organizer email address from event
     if 'organizer' in ical.vevent.contents:
         if hasattr(ical.vevent.organizer, 'EMAIL_param'):
             return ical.vevent.organizer.EMAIL_param
@@ -184,7 +203,8 @@ def organizer(ical):
 
 
 if __name__ == "__main__":
-    sendmail = sendmail_command  # Set sendmail to the function that returns the command
+    # Parse options and drive the interactive or non-interactive reply flow
+    sendmail_resolver = sendmail_command
     email_address = None
     accept_decline = 'ACCEPTED'
     opts, args = getopt(sys.argv[1:], "s:e:aidtD")
@@ -201,7 +221,7 @@ if __name__ == "__main__":
             sys.exit(0)
         if opt == '-s':
             # If -s is provided, override sendmail with a lambda that returns the command
-            sendmail = lambda: arg.split() 
+            sendmail_resolver = (lambda a=arg: shlex.split(a))
         if opt == '-e':
             email_address = arg
         if opt == '-i':
@@ -213,10 +233,16 @@ if __name__ == "__main__":
         if opt == '-t':
             accept_decline = 'TENTATIVE'
 
+    if not email_address:
+        sys.stderr.write("Error: Your email address must be provided with -e.\n")
+        sys.stderr.write(usage)
+        sys.exit(1)
+
     ans = get_answer(invitation)
 
-    attendees = invitation.vevent.contents.get("attendee", "")
+    attendees = invitation.vevent.contents.get("attendee", [])
     set_accept_state(attendees, accept_decline)
+
     ans.vevent.add('attendee')
     ans.vevent.attendee_list.pop()
     flag = 1
@@ -225,9 +251,10 @@ if __name__ == "__main__":
             if attendee.EMAIL_param.lower() == email_address.lower():
                 ans.vevent.attendee_list.append(attendee)
                 flag = 0
-        elif attendee.value.split(':')[1].lower() == email_address.lower():
-            ans.vevent.attendee_list.append(attendee)
-            flag = 0
+        else:
+            if attendee.value.split(':')[1].lower() == email_address.lower():
+                ans.vevent.attendee_list.append(attendee)
+                flag = 0
     if flag:
         sys.stderr.write("Seems like you have not been invited to this event!\n")
         sys.exit(1)
@@ -263,19 +290,18 @@ if __name__ == "__main__":
     else:
         mailtext = "Invalid response type provided."
 
-
     message.add_alternative(mailtext, subtype='plain')
-    message.add_alternative(ans.serialize(),
-            subtype='calendar',
-            params={'method': 'REPLY'})
+    message.add_alternative(
+        ans.serialize(),
+        subtype='calendar',
+        params={'method': 'REPLY', 'component': 'VEVENT', 'name': 'reply.ics'}
+    )
 
-    # Assuming sendmail is either a function that returns the sendmail command or the command itself
-    sendmail_command = sendmail() if callable(sendmail) else sendmail
+    sendmail_cmd = sendmail_resolver() if callable(sendmail_resolver) else sendmail_resolver
+    if not sendmail_cmd:
+        raise RuntimeError("Sendmail command is not configured. Aborting.")
 
-    if not sendmail_command:
-    raise RuntimeError("Sendmail command is not configured. Aborting.")
-
-    subprocess.run([*sendmail_command, "--", to], input=message.as_bytes(), check=True)
+    subprocess.run(sendmail_cmd, input=message.as_bytes(), check=True)
 
     # # From https://github.com/marvinthepa/mutt-ical/commit/c62488fbfa6a817e0f03f808c8cc14d771ce3c2d#diff-3248d42797b254937d2a6b11a3980df7c90a128ba41931a0dc8f4c1ed2c51d13R224
     # if accept_decline in {'ACCEPTED', 'TENTATIVE'}:


### PR DESCRIPTION
When using Msmtpq instead of Msmtp, this command

https://github.com/marvinthepa/mutt-ical/blob/cba522e6de66d34d4e215fdcd0707e21f7970562/mutt-ical.py#L224

seems to send the mail through a pager (maybe of interest that `$LESSOPEN = | lesspipe.sh %s` using `bat` at times) , so that the lines in the mail file in `~/.msmtp.queue` are all numbered. 
With Msmtp this mutt-ical.py (used for answering appointment requests under Mutt) works fine.
Since this seems rather odd to me, any explications are welcome.

The `sendmail` command, either string or function reference, confused the script.
In line 222 there was
```
Incompatible types in assignment (expression has type "str | None", target has type "str | Header")
```
once commented out, there was no more paging.

The crucial fix seems to be

```
sendmail = lambda: arg.split()  # If -s is provided, override sendmail with a lambda that returns the command
```

instead of 

```
sendmail = arg.split()
```
